### PR TITLE
Replace AbstractStateMachine with AbstractHsmState

### DIFF
--- a/_posts/2022-05-21-state-machines.md
+++ b/_posts/2022-05-21-state-machines.md
@@ -398,19 +398,19 @@ struct ThermometerStateMachine <: AbstractHsmState
   ThermometerStateMachine(parent, thermometer) = new(HsmStateInfo(parent), thermometer)
 end
 
-struct OffState <: AbstractStateMachine
+struct OffState <: AbstractHsmState
   # Looks exactly like ThermometerStateMachine, except for the constructor name.
 end
 
-struct OnState <: AbstractStateMachine
+struct OnState <: AbstractHsmState
   # Looks exactly like ThermometerStateMachine, except for the constructor name.
 end
 
-struct CelsiusState <: AbstractStateMachine
+struct CelsiusState <: AbstractHsmState
   # Looks exactly like ThermometerStateMachine, except for the constructor name.
 end
 
-struct FahrenheitState <: AbstractStateMachine
+struct FahrenheitState <: AbstractHsmState
   # Looks exactly like ThermometerStateMachine, except for the constructor name.
 end
 ```


### PR DESCRIPTION
The AbstractStateMachine type doesn't currently exist. Maybe it did in older versions of the code, but I think you meant to say AbstractHsmState here.